### PR TITLE
cache: only tar when all targets exist

### DIFF
--- a/lib/backends/s3.bash
+++ b/lib/backends/s3.bash
@@ -125,7 +125,7 @@ function cache() {
   # check that all the targets exist
   for target in "${TAR_TARGETS[@]}"; do
       if [ ! -e "$target" ]; then
-          echo "cache target '$target' does not exit - not creating tar cache and exiting"
+          echo "🚧 cache target '$target' does not exit - not creating tar cache and exiting"
           exit 0
       fi
   done
@@ -134,7 +134,7 @@ function cache() {
   TAR_FILE="${CACHE_KEY}.${BK_TAR_EXTENSION}"
   if [ ! -f "$TAR_FILE" ]; then
     TMP_FILE="$(mktemp)"
-    bsdtar "${BK_TAR_ARGS[@]}" "${TMP_FILE}" "${TAR_TARGETS}"
+    bsdtar "${BK_TAR_ARGS[@]}" "${TMP_FILE}" ${TAR_TARGETS}
     mv -f "${TMP_FILE}" "${TAR_FILE}"
     aws s3 cp --no-progress ${BK_CUSTOM_AWS_ARGS} "${TAR_FILE}" "s3://${BUCKET}/${TAR_FILE}"
   fi

--- a/lib/backends/s3.bash
+++ b/lib/backends/s3.bash
@@ -126,7 +126,16 @@ function cache() {
   TAR_FILE="${CACHE_KEY}.${BK_TAR_EXTENSION}"
   if [ ! -f "$TAR_FILE" ]; then
     TMP_FILE="$(mktemp)"
-    bsdtar "${BK_TAR_ARGS[@]}" "${TMP_FILE}" ${TAR_TARGETS}
+
+    # only add tar targets that exist
+    for target in "${TAR_TARGETS[@]}"; do
+        if [ -e "$target" ]; then
+            bsdtar "${BK_TAR_ARGS[@]}" -r -f "${TMP_FILE}" "${target}"
+        else
+            echo "skipping ${target} as it does not exist"
+        fi
+    done
+
     mv -f "${TMP_FILE}" "${TAR_FILE}"
     aws s3 cp --no-progress ${BK_CUSTOM_AWS_ARGS} "${TAR_FILE}" "s3://${BUCKET}/${TAR_FILE}"
   fi

--- a/lib/backends/s3.bash
+++ b/lib/backends/s3.bash
@@ -125,7 +125,7 @@ function cache() {
   # check that all the targets exist
   for target in "${TAR_TARGETS[@]}"; do
       if [ ! -e "$target" ]; then
-          echo "🚧 cache target '$target' does not exit - not creating tar cache and exiting"
+          echo "🚧 cache target '$target' does not exist - not creating tar cache and exiting"
           exit 0
       fi
   done


### PR DESCRIPTION
Sometimes when the plugin wants to cache, the targets it wants to tar do not exist. Since the targets do not exist, the plugin exits with a non-zero which makes a otherwise successful step fail. Now why wouldn't the targets exist ? This _likely_ because initially there was a problem with restoring the cache.

#### The fix
* Loop through the tar targets
* If a target doesn't exist on disk, we exit. Rather than create a partial cache, we just exit instead.