### PR TITLE
fix: do not treat TAR_TARGETS as an array

### DIFF
--- a/lib/backends/s3.bash
+++ b/lib/backends/s3.bash
@@ -123,7 +123,7 @@ function cache() {
   fi
 
   # check that all the targets exist
-  for target in "${TAR_TARGETS[@]}"; do
+  for target in ${TAR_TARGETS}; do
       if [ ! -e "$target" ]; then
           echo "🚧 cache target '$target' does not exist - not creating tar cache and exiting"
           exit 0


### PR DESCRIPTION
the paths array gets expanded into a string and assigned to TAR_TARGETS see https://sourcegraph.com/github.com/sourcegraph/cache-buildkite-plugin@dab404d442ba1badc70bfc2c7c6b99f4f97a7cf0/-/blob/lib/backends/s3.bash?L117-131

### Test
```
#!/bin/bash

targets=("node_modules" "yarn_cache")

others="${targets[@]}"

echo "Others: $others"

for target in ${others}; do
    echo "Target: $target"
done
```
Output:
```
Others: node_modules yarn_cache
Target: node_modules
Target: yarn_cache
```